### PR TITLE
fix(core): update vscode live server config to put source as root (78)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-    "liveServer.settings.port": 5501
+    "liveServer.settings.port": 5501,
+    "liveServer.settings.root": "/source"
 }


### PR DESCRIPTION
Updates vscode live server config to put `/source` as the root folder.

Closes #78