### PR TITLE
fix(core): remove no-unused-vars rule (81)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,6 +13,7 @@ module.exports = {
         "sourceType": "module"
     },
     "rules": {
+        "no-unused-vars": "off",
     },
     "ignorePatterns": [".github/**/*"]
 };


### PR DESCRIPTION
Removes `no-unused-vars` eslint rule.

Closes #81