### PR TITLE
docs(dev): add database function explainations

### DIFF
--- a/specs/documentation/development/README.md
+++ b/specs/documentation/development/README.md
@@ -13,4 +13,4 @@
 
 ## Code Explanations
 * Router Explanation: See comments in [`core/routing/router.js`](/source/core/routing/router.js)
-* _IN PROGRESS_ [Firebase Explanation](firebase-explanation.md)
+* [Firebase Explanation](firebase-explanation.md)

--- a/specs/documentation/development/firebase-explanation.md
+++ b/specs/documentation/development/firebase-explanation.md
@@ -7,6 +7,7 @@ This document covers the database and hosting features of Firebase.
 
 ## Topics
 * Firebase database
+* Using the database
 * Firebase hosting
 
 ## Firebase database
@@ -14,7 +15,36 @@ We are using Firebase to host our external database.
 * The database contains a representation similar to JSON with all of the recipes (both initial AND user-contributed ones).
 * The initial JSON files from the Spoonacular API have been imported into the database as our starting data.
 
-INSERT MORE INFO ABOUT HOW THE `core/database/database.js` FUNCTIONS WORK
+## Using the database
+To use database functionality, first import [`database.js`](/source/core/database/database.js) in your JS file.
+
+`import { Database } from "/source/core/database/database.js";`
+
+Secondly, fill out `apiKey` in [`/source/config.json`](/source/config.json).  
+
+> **IMPORTANT: NEVER** commit `config.json` with the API key filled out.  
+> To avoid this, execute `git update-index --assume-unchanged config.json` to prevent it from being staged.
+
+Lastly, create an instance of the `Database` class.
+
+`const db = new Database();`
+
+There are three functions you can utilize:
+* `getRecipes`  
+Returns an array of all recipe objects in the database.
+
+* `pushRecipe(recipe)`  
+Push a recipe object to the end of the database.  
+Although any object can be pushed, please only push valid recipes.
+
+* `updateRecipe(recipe, index)`  
+Replace a recipe object at the specified index in the database.  
+Although any object can replace a recipe, please only serve valid recipes.
+
+Note, these are all `async` functions so you may need to use keywords such as `await`.
+
+
+Also see: Comments in [`core/database/database.js`](/source/core/database/database.js)
 
 
 ## Firebase hosting


### PR DESCRIPTION
Add development docs to cover database functions.

Closes #131 