### PR TITLE
Feat/224 recipe videos

### DIFF
--- a/source/components/recipe-contribute/recipe-contribute.js
+++ b/source/components/recipe-contribute/recipe-contribute.js
@@ -111,6 +111,12 @@ class RecipeContribute extends YummyRecipesComponent {
         const isFormValid = formElement.checkValidity();
         formElement.reportValidity();
 
+        // If video is invalid then alert user and do not continue
+        if (!this.checkVideoValidity()) {
+          alert("Video link is not valid");
+          return;
+        }
+
         // Add recipe if form is valid
         if (isFormValid) {
           this.saveRecipe(recipe, true);
@@ -219,6 +225,12 @@ class RecipeContribute extends YummyRecipesComponent {
         const isFormValid = formElement.checkValidity();
         formElement.reportValidity();
 
+        // If video is invalid then alert user and do not continue
+        if (!this.checkVideoValidity()) {
+          alert("Video link is not valid");
+          return;
+        }
+
         // Update recipe if form is valid
         if (isFormValid) {
           this.saveRecipe(recipe, false);
@@ -292,8 +304,9 @@ class RecipeContribute extends YummyRecipesComponent {
     ).value;
     recipe.metadata.author =
       this.shadowRoot.querySelector("#input-author").value;
-    recipe.metadata.video =
-      this.shadowRoot.querySelector("#input-video-url").value;
+    recipe.metadata.video = this.getVideoEmbedURL(
+      this.shadowRoot.querySelector("#input-video-url").value
+    );
     recipe.info.readyInMinutes =
       this.shadowRoot.querySelector("#input-time").value;
     recipe.info.pricePerServings =
@@ -376,6 +389,45 @@ class RecipeContribute extends YummyRecipesComponent {
       });
 
       document.dispatchEvent(routerEvent);
+    }
+  }
+
+  /**
+   * Checks if YouTube video link in form is a valid link or empty string.
+   * Regex from https://stackoverflow.com/a/9102270.
+   *
+   * @returns {boolean} True if valid video link or empty string, false otherwise.
+   */
+  checkVideoValidity() {
+    const url = this.shadowRoot.getElementById("input-video-url").value;
+    if (url == "") {
+      return true;
+    }
+    const regExp =
+      /^.*(youtu\.be\/|v\/|u\/\w\/|embed\/|watch\?v=|&v=)([^#&?]*).*/;
+    const match = url.match(regExp);
+    if (match && match[2].length == 11) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  /**
+   * Converts a valid YouTube video link into a valid embed link.
+   * Regex from https://stackoverflow.com/a/9102270.
+   *
+   * @param {string} url - A string that represents a YouTube video link.
+   * @returns {string} Returns YouTube embed link or empty string if not a valid video URL.
+   */
+  getVideoEmbedURL(url) {
+    const regExp =
+      /^.*(youtu\.be\/|v\/|u\/\w\/|embed\/|watch\?v=|&v=)([^#&?]*).*/;
+    const match = url.match(regExp);
+    if (match && match[2].length == 11) {
+      return "https://www.youtube.com/embed/" + match[2];
+    } else {
+      return "";
     }
   }
 }

--- a/source/components/recipe-contribute/recipe-contribute.js
+++ b/source/components/recipe-contribute/recipe-contribute.js
@@ -73,6 +73,7 @@ class RecipeContribute extends YummyRecipesComponent {
         title: "",
         author: "",
         image: "static/common/demorecipe.jpg",
+        video: "",
       },
       info: {
         readyInMinutes: 0,
@@ -179,6 +180,10 @@ class RecipeContribute extends YummyRecipesComponent {
       recipe.metadata.title;
     this.shadowRoot.querySelector("#input-author").value =
       recipe.metadata.author;
+    if (recipe.metadata.video != undefined) {
+      this.shadowRoot.querySelector("#input-video-url").value =
+        recipe.metadata.video;
+    }
     this.shadowRoot.querySelector("#input-time").value =
       recipe.info.readyInMinutes;
     this.shadowRoot.querySelector("#input-cost").value =
@@ -287,6 +292,8 @@ class RecipeContribute extends YummyRecipesComponent {
     ).value;
     recipe.metadata.author =
       this.shadowRoot.querySelector("#input-author").value;
+    recipe.metadata.video =
+      this.shadowRoot.querySelector("#input-video-url").value;
     recipe.info.readyInMinutes =
       this.shadowRoot.querySelector("#input-time").value;
     recipe.info.pricePerServings =

--- a/source/components/recipe-contribute/recipe-contribute.js
+++ b/source/components/recipe-contribute/recipe-contribute.js
@@ -58,6 +58,35 @@ class RecipeContribute extends YummyRecipesComponent {
           }
         }
       });
+
+    /**
+     * Video field handler to check if link is valid YouTube video or field
+     * is empty. Regex from https://stackoverflow.com/a/9102270.
+     */
+    const videoUrlInput = this.shadowRoot.getElementById("input-video-url");
+
+    videoUrlInput.addEventListener("input", () => {
+      // Get form value
+      const url = videoUrlInput.value;
+
+      // If video field is blank then allow it and return
+      if (url == "") {
+        videoUrlInput.setCustomValidity("");
+        return;
+      }
+
+      // Get regex
+      const regExp =
+        /^.*(youtu\.be\/|v\/|u\/\w\/|embed\/|watch\?v=|&v=)([^#&?]*).*/;
+      const match = url.match(regExp);
+
+      // If regex worked and video ID is 11 characters then link is valid
+      if (match && match[2].length === 11) {
+        videoUrlInput.setCustomValidity("");
+      } else {
+        videoUrlInput.setCustomValidity("Video link is not valid.");
+      }
+    });
   }
 
   /**
@@ -111,15 +140,10 @@ class RecipeContribute extends YummyRecipesComponent {
         const isFormValid = formElement.checkValidity();
         formElement.reportValidity();
 
-        // If video is invalid then alert user and do not continue
-        if (!this.checkVideoValidity()) {
-          alert("Video link is not valid");
-          return;
-        }
-
         // Add recipe if form is valid
         if (isFormValid) {
-          this.saveRecipe(recipe, true);
+          //this.saveRecipe(recipe, true);
+          alert("yay");
         }
       });
 
@@ -224,12 +248,6 @@ class RecipeContribute extends YummyRecipesComponent {
         const formElement = this.shadowRoot.querySelector("#contribute-form");
         const isFormValid = formElement.checkValidity();
         formElement.reportValidity();
-
-        // If video is invalid then alert user and do not continue
-        if (!this.checkVideoValidity()) {
-          alert("Video link is not valid");
-          return;
-        }
 
         // Update recipe if form is valid
         if (isFormValid) {
@@ -389,27 +407,6 @@ class RecipeContribute extends YummyRecipesComponent {
       });
 
       document.dispatchEvent(routerEvent);
-    }
-  }
-
-  /**
-   * Checks if YouTube video link in form is a valid link or empty string.
-   * Regex from https://stackoverflow.com/a/9102270.
-   *
-   * @returns {boolean} True if valid video link or empty string, false otherwise.
-   */
-  checkVideoValidity() {
-    const url = this.shadowRoot.getElementById("input-video-url").value;
-    if (url == "") {
-      return true;
-    }
-    const regExp =
-      /^.*(youtu\.be\/|v\/|u\/\w\/|embed\/|watch\?v=|&v=)([^#&?]*).*/;
-    const match = url.match(regExp);
-    if (match && match[2].length === 11) {
-      return true;
-    } else {
-      return false;
     }
   }
 

--- a/source/components/recipe-contribute/recipe-contribute.js
+++ b/source/components/recipe-contribute/recipe-contribute.js
@@ -406,7 +406,7 @@ class RecipeContribute extends YummyRecipesComponent {
     const regExp =
       /^.*(youtu\.be\/|v\/|u\/\w\/|embed\/|watch\?v=|&v=)([^#&?]*).*/;
     const match = url.match(regExp);
-    if (match && match[2].length == 11) {
+    if (match && match[2].length === 11) {
       return true;
     } else {
       return false;
@@ -424,7 +424,7 @@ class RecipeContribute extends YummyRecipesComponent {
     const regExp =
       /^.*(youtu\.be\/|v\/|u\/\w\/|embed\/|watch\?v=|&v=)([^#&?]*).*/;
     const match = url.match(regExp);
-    if (match && match[2].length == 11) {
+    if (match && match[2].length === 11) {
       return "https://www.youtube.com/embed/" + match[2];
     } else {
       return "";

--- a/source/components/recipe-contribute/recipe-contribute.js
+++ b/source/components/recipe-contribute/recipe-contribute.js
@@ -142,8 +142,7 @@ class RecipeContribute extends YummyRecipesComponent {
 
         // Add recipe if form is valid
         if (isFormValid) {
-          //this.saveRecipe(recipe, true);
-          alert("yay");
+          this.saveRecipe(recipe, true);
         }
       });
 

--- a/source/components/recipe-details/recipe-details.css
+++ b/source/components/recipe-details/recipe-details.css
@@ -126,3 +126,8 @@
   font-size: 20px;
   margin: 5px 10px 0 0;
 }
+
+/* Do not change display: none */
+#recipe-video {
+  display: none;
+}

--- a/source/components/recipe-details/recipe-details.html
+++ b/source/components/recipe-details/recipe-details.html
@@ -4,8 +4,16 @@
   type="text/css"
   href="http://fonts.googleapis.com/css?family=Ubuntu:regular,bold&subset=Latin"
 />
-
 <div class="recipe">
+  <iframe
+    id="recipe-video"
+    width="560"
+    height="315"
+    title="YouTube video player"
+    frameborder="0"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+    allowfullscreen
+  ></iframe>
   <!-- This is the first row of the page, including the image and the author box-->
   <div class="first-row">
     <img class="recipe-image" src="" />

--- a/source/components/recipe-details/recipe-details.js
+++ b/source/components/recipe-details/recipe-details.js
@@ -119,6 +119,13 @@ class RecipeDetails extends YummyRecipesComponent {
         }
       });
 
+    // Display recipe video if the recipe has a link
+    if (recipe.metadata.video != undefined && recipe.metadata.video != "") {
+      this.shadowRoot.getElementById("recipe-video").style.display = "block";
+      this.shadowRoot.getElementById("recipe-video").src =
+        recipe.metadata.video;
+    }
+
     // This is the first row of the page, including the image and the author box
     this.shadowRoot.querySelector(".recipe-image").src = recipe.metadata.image;
     this.shadowRoot.querySelector(".recipe-image").alt = recipe.metadata.title;


### PR DESCRIPTION
Implemented recipe video field in form. Accepts any valid YouTube video link.
The field data is converted into a YouTube embed link of the form `https://youtube.com/embed/{id}`
Then, the data gets written to `recipes/{index}/metadata/video` in the database.
The user is alerted if the entry is invalid and can only submit if the field is empty or a valid link.

Also implemented recipe video on recipe details page.
There is an `iframe` that defaults to `display: none` unless `metadata/video` is non-empty.
If `metadata/video` is non-empty then the `iframe` will be `display: block` and `src` set to the embed link.

Closes #224 