### PR TITLE
style(recipe-details): move video to correct place

### DIFF
--- a/source/components/recipe-details/recipe-details.css
+++ b/source/components/recipe-details/recipe-details.css
@@ -131,6 +131,7 @@
 
 /* Do not change display: none */
 #recipe-video {
+  margin-top: 10px;
   display: none;
 }
 
@@ -201,4 +202,15 @@ button:active {
 
 #time-input-container > div {
   display: flex;
+}
+
+.direction-title {
+  display: flex;
+  column-gap: 10px;
+  align-items: center;
+}
+
+#direction-text-button,
+#direction-video-button {
+  display: none;
 }

--- a/source/components/recipe-details/recipe-details.html
+++ b/source/components/recipe-details/recipe-details.html
@@ -6,15 +6,6 @@
 />
 
 <div class="recipe">
-  <iframe
-    id="recipe-video"
-    width="560"
-    height="315"
-    title="YouTube video player"
-    frameborder="0"
-    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-    allowfullscreen
-  ></iframe>
   <!-- This is the first row of the page, including the image and the author box-->
   <div class="first-row">
     <img class="recipe-image" src="" />
@@ -107,7 +98,24 @@
 
   <!-- Direction box-->
   <div class="direction-box detail-box">
-    <div class="direction-title detail-box-title">Directions:</div>
+    <div class="direction-title">
+      <div class="detail-box-title">Directions:</div>
+      <button id="direction-video-button" class="first-row-button">
+        Switch to Video
+      </button>
+      <button id="direction-text-button" class="first-row-button">
+        Switch to Text
+      </button>
+    </div>
     <p class="direction-list detail-box-content"></p>
+    <iframe
+      id="recipe-video"
+      width="560"
+      height="315"
+      title="YouTube video player"
+      frameborder="0"
+      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+      allowfullscreen
+    ></iframe>
   </div>
 </div>

--- a/source/components/recipe-details/recipe-details.js
+++ b/source/components/recipe-details/recipe-details.js
@@ -128,11 +128,29 @@ class RecipeDetails extends YummyRecipesComponent {
         }
       });
 
-    // Display recipe video if the recipe has a link
+    // Add video embed to directions if video exists
+    // Will not show by default (user must click "Switch to Video")
     if (recipe.metadata.video != undefined && recipe.metadata.video != "") {
-      this.shadowRoot.getElementById("recipe-video").style.display = "block";
       this.shadowRoot.getElementById("recipe-video").src =
         recipe.metadata.video;
+
+      // Display video button
+      this.shadowRoot.getElementById("direction-video-button").style.display =
+        "block";
+
+      // Event handler for video button
+      this.shadowRoot
+        .getElementById("direction-video-button")
+        .addEventListener("click", () => {
+          this.switchToVideo();
+        });
+
+      // Event handler for text button
+      this.shadowRoot
+        .getElementById("direction-text-button")
+        .addEventListener("click", () => {
+          this.switchToText();
+        });
     }
 
     // This is the first row of the page, including the image and the author box
@@ -311,6 +329,36 @@ class RecipeDetails extends YummyRecipesComponent {
 
     this.setTime();
     this.totalTime -= 1;
+  }
+
+  /**
+   * Switches from text directions to video directions
+   */
+  switchToVideo() {
+    // Toggle buttons
+    this.shadowRoot.getElementById("direction-video-button").style.display =
+      "none";
+    this.shadowRoot.getElementById("direction-text-button").style.display =
+      "block";
+
+    // Show video & hide text
+    this.shadowRoot.querySelector(".direction-list").style.display = "none";
+    this.shadowRoot.getElementById("recipe-video").style.display = "block";
+  }
+
+  /**
+   * Switches from video directions to text directions
+   */
+  switchToText() {
+    // Toggle buttons
+    this.shadowRoot.getElementById("direction-video-button").style.display =
+      "block";
+    this.shadowRoot.getElementById("direction-text-button").style.display =
+      "none";
+
+    // Show video & hide text
+    this.shadowRoot.querySelector(".direction-list").style.display = "block";
+    this.shadowRoot.getElementById("recipe-video").style.display = "none";
   }
 }
 


### PR DESCRIPTION
This branch moves the video on recipe details to the directions box and has the following behavior if the video exists:
- Initially displays no video, only text directions. Has button called "Switch to Video"
- When "Switch to Video" is clicked, button changes to "Switch to Text" and text is replaced by video embed.
- When "Switch to Text" is clicked, button changes to "Switch to Video" and video embed is replaced by text.

Closes #316