### PR TITLE
Fix/323 Meal Planner Routing

### DIFF
--- a/source/components/meal-planner/meal-planner.js
+++ b/source/components/meal-planner/meal-planner.js
@@ -23,13 +23,14 @@ class MealPlanner extends YummyRecipesComponent {
         detail: {
           route: "meal-planner",
           params: [],
+          searchParams: {
+            ids: "-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1",
+          },
         },
         bubbles: true,
         composed: true,
       });
       this.dispatchEvent(routerEvent);
-      window.location.href +=
-        "?ids=-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1";
       return;
     }
 


### PR DESCRIPTION
Part 1 of #323.

When the meal planner URL is not a valid format, route to an empty meal planner.
This behavior now utilizes the `searchParams` feature in the router.
Currently, the query string is appended to the URL which causes it to be appended again in some cases.