### PR TITLE
fix(recipe-search): fix typo and remove unnecessary comment

### DIFF
--- a/source/components/recipe-search/recipe-search.js
+++ b/source/components/recipe-search/recipe-search.js
@@ -319,7 +319,7 @@ class RecipeSearch extends YummyRecipesComponent {
           for (const recipe of pageRecipes) {
             this.shadowRoot
               .getElementById("recipe-card-grid")
-              .appendChild(this.createRecipeCard(recipe.recipe, recipe.indedx));
+              .appendChild(this.createRecipeCard(recipe.recipe, recipe.index));
           }
 
           // Change url to have page set to the current page number
@@ -391,9 +391,6 @@ class RecipeSearch extends YummyRecipesComponent {
 
       // Populate page initially with first recipePerPage recipes
       for (let i = 0; i < recipePerPage; i++) {
-        /**
-         * Closes filters form when clicking on "X" icon.
-         */
         this.shadowRoot
           .getElementById("recipe-card-grid")
           .appendChild(


### PR DESCRIPTION
Fix typo causing bug for all recipe cards on pages >= 2 to go to home page instead of details page.

Fixes #343