### PR TITLE
style(timer): fix buttons overlapping with input

### DIFF
--- a/source/components/cooking-mode/cooking-mode.css
+++ b/source/components/cooking-mode/cooking-mode.css
@@ -31,7 +31,7 @@
   flex-direction: row;
   justify-content: space-around;
   position: absolute;
-  bottom: 30px;
+  bottom: 2vh;
 }
 
 #start-pause-button,
@@ -44,6 +44,7 @@
   font-size: 45;
   color: white;
   width: 145px;
+  margin-left: 1vw;
 }
 #timer-display-container {
   height: 80%;
@@ -170,8 +171,4 @@ main {
 #input-minutes-label,
 #input-seconds-label {
   font-size: 120%;
-}
-
-.divider {
-  width: 5px;
 }

--- a/source/components/cooking-mode/cooking-mode.html
+++ b/source/components/cooking-mode/cooking-mode.html
@@ -39,8 +39,6 @@
       </div>
       <div id="timer-button-grid">
         <button id="start-pause-button">Start</button><br />
-        <!-- Spacing between buttons -->
-        &nbsp;&nbsp;
         <button id="reset-button">Reset</button>
       </div>
     </div>


### PR DESCRIPTION
Some small css and html changes to make buttons not overlap on slightly smaller displays. 

Closes #348 