### PR TITLE
Feat/340 refactor router search params

### DIFF
--- a/source/components/cooking-mode/cooking-mode.css
+++ b/source/components/cooking-mode/cooking-mode.css
@@ -116,10 +116,30 @@
   object-fit: cover;
 }
 
-#direction-video {
+/* #direction-video {
   display: none;
   text-align: center;
   margin-top: 10px;
+} */
+
+/* Do not change display: none */
+#direction-video-container {
+  margin-top: 10px;
+  display: none;
+  position: relative;
+  width: 100%;
+  padding-bottom: 56.25%;
+  border-radius: 10px;
+  overflow: hidden;
+}
+
+#direction-video {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
 }
 
 #img-and-video {

--- a/source/components/cooking-mode/cooking-mode.css
+++ b/source/components/cooking-mode/cooking-mode.css
@@ -116,12 +116,6 @@
   object-fit: cover;
 }
 
-/* #direction-video {
-  display: none;
-  text-align: center;
-  margin-top: 10px;
-} */
-
 /* Do not change display: none */
 #direction-video-container {
   margin-top: 10px;

--- a/source/components/cooking-mode/cooking-mode.html
+++ b/source/components/cooking-mode/cooking-mode.html
@@ -55,15 +55,7 @@
     <div id="direction"></div>
     <div id="img-and-video">
       <img src="" id="direction-img" alt="" />
-      <iframe
-        id="direction-video"
-        width="100%"
-        height="315"
-        title="YouTube video player"
-        frameborder="0"
-        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-        allowfullscreen
-      ></iframe>
+      <div id="direction-video-container"></div>
     </div>
   </section>
 </main>

--- a/source/components/cooking-mode/cooking-mode.js
+++ b/source/components/cooking-mode/cooking-mode.js
@@ -111,7 +111,7 @@ class CookingMode extends YummyRecipesComponent {
 
     // Populate image and video (if included)
     this.shadowRoot.getElementById("direction-img").alt = recipe.metadata.title;
-    if (recipe.metadata.image !== undefined && recipe.metadata.image !== "") {
+    if (recipe.metadata.image && recipe.metadata.image !== "") {
       this.shadowRoot.getElementById("direction-img").src =
         recipe.metadata.image;
     } else {
@@ -119,10 +119,17 @@ class CookingMode extends YummyRecipesComponent {
         "/static/common/defaultimg.jpeg";
     }
 
-    if (recipe.metadata.video !== undefined && recipe.metadata.video !== "") {
-      this.shadowRoot.getElementById("direction-video").style.display = "block";
-      this.shadowRoot.getElementById("direction-video").src =
-        recipe.metadata.video;
+    if (recipe.metadata.video && recipe.metadata.video !== "") {
+      this.shadowRoot.getElementById(
+        "direction-video-container"
+      ).style.display = "block";
+      const recipeVideoElement = document.createElement("iframe");
+      recipeVideoElement.setAttribute("id", "direction-video");
+      recipeVideoElement.setAttribute("allowfullscreen", "true");
+      recipeVideoElement.setAttribute("src", recipe.metadata.video);
+      this.shadowRoot
+        .getElementById("direction-video-container")
+        .appendChild(recipeVideoElement);
     }
   }
 

--- a/source/components/core/yummy-recipes-component.js
+++ b/source/components/core/yummy-recipes-component.js
@@ -24,6 +24,14 @@ export class YummyRecipesComponent extends HTMLElement {
   }
 
   /**
+   * Sets the routeUrlParams instance variable to the route's url parameters.
+   * @param {string} route - The url parameters for the route (i.e. {query: "chicken"}).
+   */
+  set urlParams(urlParams) {
+    this.routeUrlParams = urlParams;
+  }
+
+  /**
    * Fires when this component is inserted into the DOM.
    *
    * @async

--- a/source/components/meal-planner/meal-planner.js
+++ b/source/components/meal-planner/meal-planner.js
@@ -23,7 +23,7 @@ class MealPlanner extends YummyRecipesComponent {
         detail: {
           route: "meal-planner",
           params: [],
-          searchParams: {
+          urlParams: {
             ids: "-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1",
           },
         },
@@ -307,13 +307,9 @@ class MealPlanner extends YummyRecipesComponent {
    * @returns {Array|undefined} Array of recipe ids or undefined if failed.
    */
   getParams() {
-    // Get params
-    const paramString = window.location.href.split("?")[1];
-    const searchParams = new URLSearchParams(paramString);
-
     // Check if "ids" exists as a query string parameter
-    if (searchParams.has("ids")) {
-      const ids = searchParams.get("ids").split(",").map(Number);
+    if (this.routeUrlParams.ids) {
+      const ids = this.routeUrlParams.ids.split(",").map(Number);
 
       // Check if there are exactly 21 numbers
       if (ids.length === 21 && ids.every((val) => !isNaN(val))) {
@@ -331,23 +327,25 @@ class MealPlanner extends YummyRecipesComponent {
    * @param {number} recipeIndex - The replacement value of the id.
    */
   setUrl(paramIndex, recipeIndex) {
-    // Get params
-    const paramString = window.location.href.split("?")[1];
-    const searchParams = new URLSearchParams(paramString);
-
     // Replace id
-    const ids = searchParams.get("ids").split(",");
+    const ids = this.routeUrlParams.ids.split(",");
     ids[paramIndex] = recipeIndex;
 
-    const newIds = ids.join(",");
-
-    // Get URL and remove query string
-    const url = window.location.href;
-    let newUrl = url.slice(0, url.indexOf("?"));
-    newUrl += "?ids=" + newIds;
+    this.routeUrlParams.ids = ids.join(",");
 
     // Push new URL
-    history.pushState({}, "", newUrl);
+    const routerEvent = new CustomEvent("router-navigate", {
+      detail: {
+        route: "meal-planner",
+        params: [],
+        urlParams: this.routeUrlParams,
+        preventLoad: true,
+      },
+      bubbles: true,
+      composed: true,
+    });
+    this.dispatchEvent(routerEvent);
+    return;
   }
 }
 

--- a/source/components/recipe-details/recipe-details.html
+++ b/source/components/recipe-details/recipe-details.html
@@ -73,8 +73,6 @@
       </button>
     </div>
     <p class="direction-list detail-box-content"></p>
-    <div id="recipe-video-container">
-      <iframe id="recipe-video" allowfullscreen></iframe>
-    </div>
+    <div id="recipe-video-container"></div>
   </div>
 </div>

--- a/source/components/recipe-details/recipe-details.js
+++ b/source/components/recipe-details/recipe-details.js
@@ -98,9 +98,14 @@ class RecipeDetails extends YummyRecipesComponent {
 
     // Add video embed to directions if video exists
     // Will not show by default (user must click "Switch to Video")
-    if (recipe.metadata.video != undefined && recipe.metadata.video != "") {
-      this.shadowRoot.getElementById("recipe-video").src =
-        recipe.metadata.video;
+    if (recipe.metadata.video && recipe.metadata.video != "") {
+      const recipeVideoElement = document.createElement("iframe");
+      recipeVideoElement.setAttribute("id", "recipe-video");
+      recipeVideoElement.setAttribute("allowfullscreen", "true");
+      recipeVideoElement.setAttribute("src", recipe.metadata.video);
+      this.shadowRoot
+        .getElementById("recipe-video-container")
+        .appendChild(recipeVideoElement);
 
       // Display video button
       this.shadowRoot.getElementById("direction-video-button").style.display =

--- a/source/components/recipe-search/recipe-search.js
+++ b/source/components/recipe-search/recipe-search.js
@@ -333,7 +333,7 @@ class RecipeSearch extends YummyRecipesComponent {
 
       // If clicked on, click next page anchor tag
       rightArrow.addEventListener("click", (event) => {
-        const currPageNum = parseInt(this.routeUrlParams.page);
+        const currPageNum = parseInt(this.routeUrlParams.page, 10);
 
         // The page after the last page DNE
         if (currPageNum === pageCount) {

--- a/source/components/recipe-search/recipe-search.js
+++ b/source/components/recipe-search/recipe-search.js
@@ -5,7 +5,7 @@ class RecipeSearch extends YummyRecipesComponent {
   constructor() {
     super();
     this.htmlPath = "components/recipe-search/recipe-search.html";
-    this.recipe = [];
+    this.searchResultRecipes = [];
   }
 
   /**
@@ -216,18 +216,19 @@ class RecipeSearch extends YummyRecipesComponent {
     // Number # of recipes per page
     const recipePerPage = 15;
 
-    let searchRecipe = await database.searchByName(
+    this.searchResultRecipes = await database.searchByName(
       Object.entries(this.routeUrlParams)
     );
-    this.recipe = searchRecipe;
 
     // Clear out recipe card grid before we append new cards
     this.shadowRoot.getElementById("recipe-card-grid").innerHTML = "";
 
     // Apply Pagination
-    if (searchRecipe.length > recipePerPage) {
+    if (this.searchResultRecipes.length > recipePerPage) {
       // Round up (recipe length)/(amount of recipes per page)
-      const pageCount = Math.ceil(searchRecipe.length / recipePerPage);
+      const pageCount = Math.ceil(
+        this.searchResultRecipes.length / recipePerPage
+      );
       const pagDiv = this.shadowRoot.getElementById("recipe-pagination");
 
       // Create left arrow icon for navigation
@@ -282,7 +283,10 @@ class RecipeSearch extends YummyRecipesComponent {
           const recipeEnd = recipeStart + recipePerPage;
 
           // Get recipe from start (inclusive) to end (exclusive)
-          let pageRecipes = this.recipe.slice(recipeStart, recipeEnd);
+          let pageRecipes = this.searchResultRecipes.slice(
+            recipeStart,
+            recipeEnd
+          );
 
           // Clear out recipe card grid before we append new cards
           this.shadowRoot.getElementById("recipe-card-grid").innerHTML = "";
@@ -356,7 +360,10 @@ class RecipeSearch extends YummyRecipesComponent {
         this.shadowRoot
           .getElementById("recipe-card-grid")
           .appendChild(
-            this.createRecipeCard(searchRecipe[i].recipe, searchRecipe[i].index)
+            this.createRecipeCard(
+              this.searchResultRecipes[i].recipe,
+              this.searchResultRecipes[i].index
+            )
           );
       }
 
@@ -390,7 +397,7 @@ class RecipeSearch extends YummyRecipesComponent {
       }
     } else {
       // For the case that pagination is not required
-      for (const recipe of searchRecipe) {
+      for (const recipe of this.searchResultRecipes) {
         this.shadowRoot
           .getElementById("recipe-card-grid")
           .appendChild(this.createRecipeCard(recipe.recipe, recipe.index));

--- a/source/components/recipe-search/recipe-search.js
+++ b/source/components/recipe-search/recipe-search.js
@@ -12,14 +12,10 @@ class RecipeSearch extends YummyRecipesComponent {
    * Initializes the search page.
    */
   async setupElement() {
-    let paramString = window.location.href.split("?")[1];
-    let queryString = new URLSearchParams(paramString);
-    let paramArray = [];
-    for (let p of queryString) {
-      paramArray.push(p);
-    }
+    console.log("routeurlparams");
+    console.log(this.routeUrlParams);
 
-    if (paramArray.length > 0) {
+    if (Object.keys(this.routeUrlParams).length > 0) {
       this.populateForm();
       this.getSearchResults();
     }
@@ -61,66 +57,63 @@ class RecipeSearch extends YummyRecipesComponent {
    * Populates the query box and filters form based on URL parameters.
    */
   populateForm() {
-    const paramString = window.location.href.split("?")[1];
-    const searchParams = new URLSearchParams(paramString);
-
     // Query
-    if (searchParams.has("query")) {
+    if (this.routeUrlParams.query) {
       this.shadowRoot.getElementById("search-input").value =
-        searchParams.get("query");
+        this.routeUrlParams.query;
     }
 
     // Gluten free
-    if (searchParams.get("glutenFree")) {
+    if (this.routeUrlParams.glutenFree) {
       this.shadowRoot.getElementById("input-gluten-free").checked = true;
     }
 
     // Healthy
-    if (searchParams.get("healthy")) {
+    if (this.routeUrlParams.healthy) {
       this.shadowRoot.getElementById("input-healthy").checked = true;
     }
 
     // High protein
-    if (searchParams.get("highProtein")) {
+    if (this.routeUrlParams.highProtein) {
       this.shadowRoot.getElementById("input-high-protein").checked = true;
     }
 
     // Vegan
-    if (searchParams.get("vegan")) {
+    if (this.routeUrlParams.vegan) {
       this.shadowRoot.getElementById("input-vegan").checked = true;
     }
 
     // Vegetarian
-    if (searchParams.get("vegetarian")) {
+    if (this.routeUrlParams.vegetarian) {
       this.shadowRoot.getElementById("input-vegetarian").checked = true;
     }
 
     // Cost min
-    if (searchParams.has("costmin")) {
+    if (this.routeUrlParams.costmin) {
       this.shadowRoot.getElementById("input-cost-min").value =
-        searchParams.get("costmin");
+        this.routeUrlParams.costmin;
     }
 
     // Cost max
-    if (searchParams.has("costmax")) {
+    if (this.routeUrlParams.costmax) {
       this.shadowRoot.getElementById("input-cost-max").value =
-        searchParams.get("costmax");
+        this.routeUrlParams.costmax;
     }
 
     // Sort cost
-    if (searchParams.has("sortcost")) {
-      if (searchParams.get("sortcost") === "desc") {
+    if (this.routeUrlParams.sortcost) {
+      if (this.routeUrlParams.sortcost === "desc") {
         this.shadowRoot.getElementById("sort-cost-descending").checked = true;
-      } else if (searchParams.get("sortcost") === "asc") {
+      } else if (this.routeUrlParams.sortcost === "asc") {
         this.shadowRoot.getElementById("sort-cost-ascending").checked = true;
       }
     }
 
     // Sort time
-    if (searchParams.has("sorttime")) {
-      if (searchParams.get("sorttime") === "desc") {
+    if (this.routeUrlParams.sorttime) {
+      if (this.routeUrlParams.sorttime === "desc") {
         this.shadowRoot.getElementById("sort-time-descending").checked = true;
-      } else if (searchParams.get("sorttime") === "asc") {
+      } else if (this.routeUrlParams.sorttime === "asc") {
         this.shadowRoot.getElementById("sort-time-ascending").checked = true;
       }
     }
@@ -145,44 +138,43 @@ class RecipeSearch extends YummyRecipesComponent {
 
     // Query
     if (this.shadowRoot.getElementById("search-input").value != "") {
-      searchParams["query"] =
-        this.shadowRoot.getElementById("search-input").value;
+      searchParams.query = this.shadowRoot.getElementById("search-input").value;
     }
 
     // Gluten free
     if (this.shadowRoot.getElementById("input-gluten-free").checked) {
-      searchParams["glutenFree"] = true;
+      searchParams.glutenFree = true;
     }
 
     // Healthy
     if (this.shadowRoot.getElementById("input-healthy").checked) {
-      searchParams["healthy"] = true;
+      searchParams.healthy = true;
     }
 
     // High protein
     if (this.shadowRoot.getElementById("input-high-protein").checked) {
-      searchParams["highProtein"] = true;
+      searchParams.highProtein = true;
     }
 
     // Vegan
     if (this.shadowRoot.getElementById("input-vegan").checked) {
-      searchParams["vegan"] = true;
+      searchParams.vegan = true;
     }
 
     // Vegetarian
     if (this.shadowRoot.getElementById("input-vegetarian").checked) {
-      searchParams["vegetarian"] = true;
+      searchParams.vegetarian = true;
     }
 
     // Cost min
     if (this.shadowRoot.getElementById("input-cost-min").value != "") {
-      searchParams["costmin"] =
+      searchParams.costmin =
         this.shadowRoot.getElementById("input-cost-min").value;
     }
 
     // Cost max
     if (this.shadowRoot.getElementById("input-cost-max").value != "") {
-      searchParams["costmax"] =
+      searchParams.costmax =
         this.shadowRoot.getElementById("input-cost-max").value;
     }
 
@@ -193,13 +185,13 @@ class RecipeSearch extends YummyRecipesComponent {
     if (sortSelectedElement) {
       const sortSelectedValue = sortSelectedElement.value;
       if (sortSelectedValue === "sort-time-descending") {
-        searchParams["sorttime"] = "desc";
+        searchParams.sorttime = "desc";
       } else if (sortSelectedValue === "sort-time-ascending") {
-        searchParams["sorttime"] = "asc";
+        searchParams.sorttime = "asc";
       } else if (sortSelectedValue === "sort-cost-descending") {
-        searchParams["sortcost"] = "desc";
+        searchParams.sortcost = "desc";
       } else if (sortSelectedValue === "sort-cost-ascending") {
-        searchParams["sortcost"] = "asc";
+        searchParams.sortcost = "asc";
       }
     }
 
@@ -208,7 +200,7 @@ class RecipeSearch extends YummyRecipesComponent {
       detail: {
         route: "recipe-search",
         params: [],
-        searchParams: searchParams,
+        urlParams: searchParams,
       },
       bubbles: true,
       composed: true,

--- a/source/components/recipe-search/recipe-search.js
+++ b/source/components/recipe-search/recipe-search.js
@@ -237,7 +237,7 @@ class RecipeSearch extends YummyRecipesComponent {
 
       // If clicked on, click previous page anchor tag
       leftArrow.addEventListener("click", (event) => {
-        const currPageNum = parseInt(this.routeUrlParams.page);
+        const currPageNum = parseInt(this.routeUrlParams.page, 10);
 
         // The page before page 1 DNE
         if (currPageNum === 1) {

--- a/source/components/recipe-search/recipe-search.js
+++ b/source/components/recipe-search/recipe-search.js
@@ -360,27 +360,31 @@ class RecipeSearch extends YummyRecipesComponent {
           );
       }
 
-      // Set url to have page = 1 on initial load
-      const url = window.location.href;
-
       // If url already has a page, then do not repeat page count
-      if (url.includes("&page")) {
-        // Get page number before the clicked on page number
-        let lastPageNum = "";
+      if (this.routeUrlParams.page) {
+        // Get current page num
+        const currPageNum = this.routeUrlParams.page;
 
-        const pageChunk = url.slice(url.indexOf("&page="), url.length);
-        const equalIndex = pageChunk.indexOf("=");
-
-        for (let i = equalIndex + 1; i < pageChunk.length; i++) {
-          lastPageNum = lastPageNum + pageChunk[i];
-        }
         // Click the current page anchor again so its highlighted in pagination nav bar
-        this.shadowRoot.getElementById(lastPageNum).click();
+        this.shadowRoot.getElementById(currPageNum).click();
       } else {
-        // Gets the URL without ?page=, then adds it back with the current page number
-        const newUrl = url + "&page=" + 1;
+        // Add page=1 to url params if no page exists in the url
+        this.routeUrlParams.page = 1;
 
-        history.pushState({}, "", newUrl);
+        // Replace current state without reloading
+        const routerEvent = new CustomEvent("router-navigate", {
+          detail: {
+            route: "recipe-search",
+            params: [],
+            urlParams: this.routeUrlParams,
+            preventLoad: true,
+            replaceState: true,
+          },
+          bubbles: true,
+          composed: true,
+        });
+
+        document.dispatchEvent(routerEvent);
 
         this.shadowRoot.getElementById("1").classList.add("active");
       }

--- a/source/core/routing/router.js
+++ b/source/core/routing/router.js
@@ -71,7 +71,7 @@ function routerSetup() {
    * @listens router-navigate
    */
   document.addEventListener("router-navigate", (event) => {
-    loadRoute(event.detail.route, event.detail.params);
+    loadRoute(event.detail.route, event.detail.params, event.detail.urlParams);
 
     // If we are pushing this route to the history state
     // AND we aren't already on the page, push the history state
@@ -127,14 +127,19 @@ function routerSetup() {
  * We assume all web components are named the same as their routes.
  * @param {string} route - The route to load on the page (i.e. "home-page").
  * @param {number[]} params - The parameters in the URL (i.e. [123]).
+ * @param {Object} urlParams - The GET parameters for the route (i.e. {query: "chicken"}).
  */
-function loadRoute(route, params) {
+function loadRoute(route, params, urlParams) {
+  // Create new component based on route
   const contentElement = document.getElementById("content");
   const newRouteElement = document.createElement(
     routePatterns[route].component
   );
+
+  // Set instance variables of new component
   newRouteElement.params = params;
   newRouteElement.route = route;
+  newRouteElement.urlParams = urlParams;
 
   // If there is an element loaded already, replace it with new one.
   // Otherwise, add new one.
@@ -159,6 +164,7 @@ function loadRoute(route, params) {
 function navigateFromUrl(url) {
   const initialRoute = getRoutefromUrl(url);
   const routeParams = getParamsFromUrl(url);
+  const routeUrlParams = getUrlParamsFromUrl(url);
 
   if (initialRoute) {
     loadRoute(initialRoute, routeParams);
@@ -166,6 +172,7 @@ function navigateFromUrl(url) {
       {
         route: initialRoute,
         params: routeParams,
+        urlParams: routeUrlParams,
       },
       initialRoute,
       url
@@ -280,4 +287,20 @@ function getParamsFromUrl(url) {
   }
 
   return params;
+}
+
+/**
+ * Gets the GET (url) parameters from a given URL.
+ * @param {string} url - The provided URL to extract url parameters from.
+ * @returns {Object} - The GET parameters from the URL (i.e. {query: "chicken"}).
+ */
+function getUrlParamsFromUrl(url) {
+  // Return empty object if no parameters
+  if (!url.includes("?")) {
+    return {};
+  }
+
+  const paramString = window.location.href.split("?")[1];
+  const urlParamsObj = new URLSearchParams(paramString);
+  return Object.fromEntries(urlParamsObj);
 }

--- a/source/core/routing/router.js
+++ b/source/core/routing/router.js
@@ -67,11 +67,19 @@ function routerSetup() {
    * @param {string} event.detail.route - The route to navigate to (i.e. "home-page").
    * @param {number[]} event.detail.params - The parameters for the route (i.e. [123]).
    * @param {Object} event.state.urlParams - The GET parameters for the route (i.e. {query: "chicken"}).
-   * @param {boolean} event.detail.preventStatePush - Whether to push this entry to the browser's history log.
+   * @param {boolean} event.state.preventLoad - Setting to true will prevent the page from loading the route.
+   * @param {boolean} event.detail.preventStatePush - Setting to true will prevent pushing this entry to the browser's history log.
    * @listens router-navigate
    */
   document.addEventListener("router-navigate", (event) => {
-    loadRoute(event.detail.route, event.detail.params, event.detail.urlParams);
+    // If we are loading the page to a new route
+    if (!event.detail.preventLoad) {
+      loadRoute(
+        event.detail.route,
+        event.detail.params,
+        event.detail.urlParams
+      );
+    }
 
     // If we are pushing this route to the history state
     // AND we aren't already on the page, push the history state

--- a/source/core/routing/router.js
+++ b/source/core/routing/router.js
@@ -66,7 +66,7 @@ function routerSetup() {
    * @param {Object} event - The event object
    * @param {string} event.detail.route - The route to navigate to (i.e. "home-page").
    * @param {number[]} event.detail.params - The parameters for the route (i.e. [123]).
-   * @param {Object} event.state.searchParams - The search parameters for the route (i.e. {query: "chicken"}).
+   * @param {Object} event.state.urlParams - The GET parameters for the route (i.e. {query: "chicken"}).
    * @param {boolean} event.detail.preventStatePush - Whether to push this entry to the browser's history log.
    * @listens router-navigate
    */
@@ -78,14 +78,14 @@ function routerSetup() {
     const url = getUrlFromRoute(
       event.detail.route,
       event.detail.params,
-      event.detail.searchParams
+      event.detail.urlParams
     );
     if (!event.detail.preventStatePush && window.location.hash !== url) {
       history.pushState(
         {
           route: event.detail.route,
           params: event.detail.params,
-          searchParams: event.detail.searchParams,
+          urlParams: event.detail.urlParams,
         },
         event.detail.route,
         url
@@ -102,7 +102,7 @@ function routerSetup() {
    * @param {Object} event - The event object
    * @param {string} event.state.route - The route to navigate to (i.e. "home-page").
    * @param {number[]} event.state.params - The parameters for the route (i.e. [123]).
-   * @param {Object} event.state.searchParams - The search parameters for the route (i.e. {query: "chicken"}).
+   * @param {Object} event.state.urlParams - The GET parameters for the route (i.e. {query: "chicken"}).
    * @listens popstate
    */
   window.addEventListener("popstate", (event) => {
@@ -187,10 +187,10 @@ function navigateFromUrl(url) {
  * Generates correct url for a particular route
  * @param {string} route - The route (i.e. "home-page").
  * @param {number[]} params - The parameters for the route (i.e. [123]).
- * @param {Object} searchParams - The search parameters for the route (i.e. {query: "chicken"}).
+ * @param {Object} urlParams - The GET parameters for the route (i.e. {query: "chicken"}).
  * @returns {string} The URL for that particular route/params.
  */
-function getUrlFromRoute(route, params, searchParams) {
+function getUrlFromRoute(route, params, urlParams) {
   // Replace all "_" in route's pattern with provided params
   const urlPattern = routePatterns[route].url;
 
@@ -204,9 +204,9 @@ function getUrlFromRoute(route, params, searchParams) {
   }
   let finalUrl = splitUrl.join("/");
 
-  // If searchParams is defined, add GET parameters to end of URL
-  if (searchParams !== undefined && Object.keys(searchParams).length > 0) {
-    const searchParamsObj = new URLSearchParams(searchParams);
+  // If getParams is defined, add GET parameters to end of URL
+  if (urlParams && Object.keys(urlParams).length > 0) {
+    const searchParamsObj = new URLSearchParams(urlParams);
     finalUrl += `?${searchParamsObj.toString()}`;
   }
 

--- a/source/core/routing/router.js
+++ b/source/core/routing/router.js
@@ -316,7 +316,8 @@ function getParamsFromUrl(url) {
 function getUrlParamsFromUrl(url) {
   // Return empty object if no parameters
   if (!url.includes("?")) {
-    return {};
+    const emptyObj = {};
+    return emptyObj;
   }
 
   const paramString = window.location.href.split("?")[1];

--- a/source/core/routing/router.js
+++ b/source/core/routing/router.js
@@ -69,6 +69,7 @@ function routerSetup() {
    * @param {Object} event.state.urlParams - The GET parameters for the route (i.e. {query: "chicken"}).
    * @param {boolean} event.state.preventLoad - Setting to true will prevent the page from loading the route.
    * @param {boolean} event.detail.preventStatePush - Setting to true will prevent pushing this entry to the browser's history log.
+   * @param {boolean} event.detail.replaceState - Setting to true will replace the current state with the provided values.
    * @listens router-navigate
    */
   document.addEventListener("router-navigate", (event) => {
@@ -88,7 +89,17 @@ function routerSetup() {
       event.detail.params,
       event.detail.urlParams
     );
-    if (!event.detail.preventStatePush && window.location.hash !== url) {
+    if (event.detail.replaceState) {
+      history.replaceState(
+        {
+          route: event.detail.route,
+          params: event.detail.params,
+          urlParams: event.detail.urlParams,
+        },
+        event.detail.route,
+        url
+      );
+    } else if (!event.detail.preventStatePush && window.location.hash !== url) {
       history.pushState(
         {
           route: event.detail.route,

--- a/source/core/routing/router.js
+++ b/source/core/routing/router.js
@@ -175,7 +175,7 @@ function navigateFromUrl(url) {
   const routeUrlParams = getUrlParamsFromUrl(url);
 
   if (initialRoute) {
-    loadRoute(initialRoute, routeParams);
+    loadRoute(initialRoute, routeParams, routeUrlParams);
     history.replaceState(
       {
         route: initialRoute,


### PR DESCRIPTION
This branch refactors the router to have a more straightforward usage of the search params in the URL, among other small refactoring changes. It has the following changes:
- Renames `searchParams` to `urlParams`.
- Adds a `this.routeUrlParams` instance variable to every component that is updated with an object where the key represents every url parameter and the value represents the value of that parameter.
- Adds a `preventLoad` boolean to the `router-navigate` event, which does not load/reload the component on the page.
- Adds a `replaceState` boolean to the `router-navigate` event, which replaces the current state with the provided one instead of adding a new state entry.
- Refactors search page to utilize the new `this.routeUrlParams` variable rather than processing the parameters itself, including:
    - The query + filter/sort parameters.
    - How we manage the `&page=[num]` parameter.
- Refactors meal planner to utilize the new `this.routeUrlParams` variable and the router event rather than processing the parameters itself.
- FIxes a small bug related to the video iframe that caused the state entry for recipe details and cooking mode to duplicate (so the user would have to hit back twice to actually go back).

Closes #340 
Fixes #312 
Fixes #323 
Fixes #331